### PR TITLE
[#52] backport publication modal

### DIFF
--- a/invenio_app_rdm/config.py
+++ b/invenio_app_rdm/config.py
@@ -631,6 +631,9 @@ APP_RDM_DEPOSIT_FORM_QUOTA = {
 APP_RDM_DISPLAY_DECIMAL_FILE_SIZES = True
 """Display the file sizes in powers of 1000 (KB, ...) or 1024 (KiB, ...)."""
 
+APP_RDM_DEPOSIT_FORM_PUBLISH_MODAL_EXTRA = ""
+"""Additional text/html to be displayed in the publish and submit for review modal."""
+
 RDM_CITATION_STYLES = [
     ("apa", _("APA")),
     ("harvard-cite-them-right", _("Harvard")),

--- a/invenio_app_rdm/records_ui/views/deposits.py
+++ b/invenio_app_rdm/records_ui/views/deposits.py
@@ -269,6 +269,9 @@ def get_form_config(**kwargs):
                 "user-dashboard-request-details"
             ]
         ),
+        publish_modal_extra=current_app.config.get(
+            "APP_RDM_DEPOSIT_FORM_PUBLISH_MODAL_EXTRA"
+        ),
         **kwargs,
     )
 

--- a/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
+++ b/invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/deposit/RDMDepositForm.js
@@ -160,15 +160,20 @@ export class RDMDepositForm extends Component {
                 ))}
 
                 <ResourceTypeField
+                  fieldPath="metadata.resource_type"
                   options={this.vocabularies.metadata.resource_type}
                   required
                 />
                 <TitlesField
+                  fieldPath="metadata.title"
                   options={this.vocabularies.metadata.titles}
                   recordUI={record.ui}
                   required
                 />
-                <PublicationDateField required />
+                <PublicationDateField
+                  fieldPath="metadata.publication_date"
+                  required
+                />
                 <CreatibutorsField
                   label={i18next.t("Creators")}
                   labelIcon="user"
@@ -179,6 +184,7 @@ export class RDMDepositForm extends Component {
                   required
                 />
                 <DescriptionsField
+                  fieldPath="metadata.description"
                   options={this.vocabularies.metadata.descriptions}
                   recordUI={_get(record, "ui", null)}
                   editorConfig={{
@@ -247,11 +253,13 @@ export class RDMDepositForm extends Component {
                   }}
                 />
                 <SubjectsField
+                  fieldPath="metadata.subjects"
                   initialOptions={_get(record, "ui.subjects", null)}
                   limitToOptions={this.vocabularies.metadata.subjects.limit_to}
                 />
 
                 <LanguagesField
+                  fieldPath="metadata.languages"
                   initialOptions={_get(record, "ui.languages", []).filter(
                     (lang) => lang !== null
                   )} // needed because dumped empty record from backend gives [null]
@@ -263,9 +271,15 @@ export class RDMDepositForm extends Component {
                     }))
                   }
                 />
-                <DatesField options={this.vocabularies.metadata.dates} />
-                <VersionField />
-                <PublisherField />
+                <DatesField
+                  fieldPath="metadata.dates"
+                  options={this.vocabularies.metadata.dates} />
+                <VersionField
+                  fieldPath="metadata.version"
+                />
+                <PublisherField
+                  fieldPath="metadata.publisher"
+                />
               </AccordionField>
 
               <AccordionField
@@ -367,7 +381,10 @@ export class RDMDepositForm extends Component {
                 active
                 label={i18next.t("Related works")}
               >
-                <RelatedWorksField options={this.vocabularies.metadata.identifiers} />
+                <RelatedWorksField
+                  fieldPath="metadata.related_identifiers"
+                  options={this.vocabularies.metadata.identifiers}
+                />
               </AccordionField>
             </Grid.Column>
             <Ref innerRef={this.sidebarRef}>
@@ -408,6 +425,7 @@ export class RDMDepositForm extends Component {
                   </Card>
 
                   <AccessRightField
+                    fieldPath="access"
                     label={i18next.t("Visibility")}
                     labelIcon="shield"
                   />

--- a/invenio_app_rdm/theme/webpack.py
+++ b/invenio_app_rdm/theme/webpack.py
@@ -44,7 +44,7 @@ theme = WebpackThemeBundle(
                 "react-dnd-html5-backend": "^11.1.0",
                 "react-dropzone": "^11.0.0",
                 "react-i18next": "^11.11.0",
-                "react-invenio-deposit": "^0.19.0",
+                "react-invenio-deposit": "^0.20.0",
                 "react-invenio-forms": "^0.10.0",
                 "react-searchkit": "^2.0.0",
                 "yup": "^0.32.0",


### PR DESCRIPTION
- part of closing 
- first commit of our (HOPEFULLY SHORT LIVED) fork of invenio-app-rdm . 
- This change is in v10, but we are sticking to LTS versions for now (v10 just came out so probably unstable). This backports the change to v9. It's idiosyncratic and might cause some complication given it's a new feature, so it doesn't make sense to backport to the core module 9.x.